### PR TITLE
ServiceProvider: Bump version to beta. Add GenerateServiceProviderClient

### DIFF
--- a/GenerateServiceProviderClient.ps1
+++ b/GenerateServiceProviderClient.ps1
@@ -1,0 +1,1 @@
+autorest --input-file="Sherweb.Apis.ServiceProvider.OpenAPI.json" --csharp --output-folder=Sherweb.Apis.ServiceProvider\HttpClient --namespace=Sherweb.Apis.ServiceProvider --override-client-name='ServiceProviderService' --add-credentials=true --v3

--- a/NugetPackagesSourceCode/Sherweb.Apis.ServiceProvider/Sherweb.Apis.ServiceProvider.csproj
+++ b/NugetPackagesSourceCode/Sherweb.Apis.ServiceProvider/Sherweb.Apis.ServiceProvider.csproj
@@ -6,7 +6,7 @@
     <PackageId>Sherweb.Apis.ServiceProvider</PackageId>
     <PackageTags>Sherweb API Client ServiceProvider</PackageTags>
     <Description>Sherweb ServiceProvider API Client</Description>
-    <Version>1.0.0-alpha3</Version>
+    <Version>1.0.0-beta03</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Sherweb.Apis.sln
+++ b/Sherweb.Apis.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		GenerateAuthorizationClient.ps1 = GenerateAuthorizationClient.ps1
 		GenerateDistributorClient.ps1 = GenerateDistributorClient.ps1
+		GenerateServiceProviderClient.ps1 = GenerateServiceProviderClient.ps1
 		LISEZMOI.md = LISEZMOI.md
 		PublicNuget.props = PublicNuget.props
 		README.md = README.md


### PR DESCRIPTION
The `ps1` script is only to facilitate future work for devs when they will want to add endpoints to the ServiceProvider nuget and test them locally.